### PR TITLE
chore: update vue version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6721,9 +6721,9 @@
       "dev": true
     },
     "vue": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
-      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ=="
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
+      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
     },
     "vue-eslint-parser": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express": "^4.17.1",
     "http-proxy-middleware": "^0.19.1",
     "moment": "^2.24.0",
-    "vue": "^2.6.10",
+    "vue": "^2.6.11",
     "vue-router": "^3.0.7",
     "yargs-parser": "^18.1.3"
   },


### PR DESCRIPTION
Update vue version

env:
node v13.2.0
npm v6.13.1
osx 10.15.4

previously, the build script fails and showed this message
![image](https://user-images.githubusercontent.com/17358112/82986742-33fb7c00-a018-11ea-8efb-d2b37aaaefa9.png)
